### PR TITLE
Handle->DID resolution via /.well-known/atproto-did endpoint

### DIFF
--- a/Sources/ATResolve/ATResolver.swift
+++ b/Sources/ATResolve/ATResolver.swift
@@ -87,7 +87,12 @@ public struct ATResolver<Provider: ResponseProviding> {
 
 	static func checkDNS(handle: String) async -> String? {
 		do {
-			let resolver = try AsyncDNSResolver()
+			var dnsOptions = CAresDNSResolver.Options.default
+			dnsOptions.attempts = 1
+			dnsOptions.timeoutMillis = 3000
+			// Cloudflare and Google DNS servers
+			dnsOptions.servers = ["1.1.1.1", "1.0.0.1", "8.8.8.8", "8.8.4.4"]
+			let resolver = try AsyncDNSResolver(options: dnsOptions)
 			let txtRecords = try await resolver.queryTXT(
 				name: "_atproto." + handle
 			)

--- a/Sources/ATResolve/ATResolver.swift
+++ b/Sources/ATResolve/ATResolver.swift
@@ -101,20 +101,7 @@ public struct ATResolver<Provider: ResponseProviding> {
 	}
 	
 	public func didForHandle(_ handle: String) async throws -> String? {
-		if let did = try await didForDomain(handle) {
-			return did
-		}
-		
-		return try await blueskyGetProfile(handle).did
-	}
-	
-	public func blueskyGetProfile(_ actor: String) async throws -> BlueskyProfile {
-		try await provider.decodeJSON(
-			host: "public.api.bsky.app",
-			path: "/xrpc/app.bsky.actor.getProfile",
-			headers: ["Accept": "application/json"],
-			queryItems: [("actor", actor)]
-		)
+		try await didForDomain(handle)
 	}
 	
 	public func plcDirectoryQuery(

--- a/Sources/ATResolve/ATResolver.swift
+++ b/Sources/ATResolve/ATResolver.swift
@@ -40,20 +40,64 @@ public struct ATResolver<Provider: ResponseProviding> {
 	}
 	
 	public func didForDomain(_ name: String) async throws -> String? {
-		// I don't understand exactly why, but this triggers a timeout. When I do it with `dig` it returns right away...
-		if name.hasSuffix(".bsky.social") {
+		return await withTaskGroup(of: Optional<String>.self) { group in
+			let provider = provider
+			group.addTask {
+				await Self.checkWellKnown(handle: name, provider: provider)
+			}
+			
+			group.addTask {
+				await Self.checkDNS(handle: name)
+			}
+			
+			let first = await group.next()
+			if let first {
+				return first
+			}
+			
+			return await group.next() ?? nil
+		}
+	}
+	
+	static func checkWellKnown(handle: String, provider: Provider) async -> String? {
+		do {
+			let dataResult = try await provider.data(
+				for: .init(
+					host: handle,
+					path: "/.well-known/atproto-did",
+					method: .get,
+					headers: ["Accept": "text/plain;charset=UTF-8"],
+					queryItems: []
+				)
+			)
+			let result = String(data: dataResult, encoding: .utf8)
+
+			if let result {
+				//workaround if we get erroneous 200 code but body return is e.g.
+				//"404 error"
+				guard result.hasPrefix("did:") else {
+					return nil
+				}
+			}
+			return result
+		} catch {
 			return nil
 		}
-		
-		let resolver = try AsyncDNSResolver()
-		
-		let txtRecords = try await resolver.queryTXT(name: "_atproto." + name)
-		
-		let didRecord = txtRecords.first { record in
-			record.txt.hasPrefix("did=")
+	}
+
+	static func checkDNS(handle: String) async -> String? {
+		do {
+			let resolver = try AsyncDNSResolver()
+			let txtRecords = try await resolver.queryTXT(
+				name: "_atproto." + handle
+			)
+			let didRecord = txtRecords.first { record in
+				record.txt.hasPrefix("did=")
+			}
+			return didRecord?.txt.components(separatedBy: "=").last
+		} catch {
+			return nil
 		}
-		
-		return didRecord?.txt.components(separatedBy: "=").last
 	}
 	
 	public func didForHandle(_ handle: String) async throws -> String? {

--- a/Sources/ATResolve/ATResolver.swift
+++ b/Sources/ATResolve/ATResolver.swift
@@ -142,8 +142,6 @@ public struct ATResolver<Provider: ResponseProviding> {
 	}
 }
 
-extension ATResolver: Sendable where Provider: Sendable {}
-
 #if canImport(Foundation)
 import Foundation
 

--- a/Sources/ATResolve/ATResolver.swift
+++ b/Sources/ATResolve/ATResolver.swift
@@ -87,10 +87,8 @@ public struct ATResolver<Provider: ResponseProviding> {
 
 	static func checkDNS(handle: String) async -> String? {
 		do {
+			// Only check Cloudflare and Google DNS servers
 			var dnsOptions = CAresDNSResolver.Options.default
-			dnsOptions.attempts = 1
-			dnsOptions.timeoutMillis = 3000
-			// Cloudflare and Google DNS servers
 			dnsOptions.servers = ["1.1.1.1", "1.0.0.1", "8.8.8.8", "8.8.4.4"]
 			let resolver = try AsyncDNSResolver(options: dnsOptions)
 			let txtRecords = try await resolver.queryTXT(

--- a/Sources/ATResolve/ATResolver.swift
+++ b/Sources/ATResolve/ATResolver.swift
@@ -101,7 +101,20 @@ public struct ATResolver<Provider: ResponseProviding> {
 	}
 	
 	public func didForHandle(_ handle: String) async throws -> String? {
-		try await didForDomain(handle)
+		if let did = try await didForDomain(handle) {
+			return did
+		}
+		
+		return try await blueskyGetProfile(handle).did
+	}
+	
+	public func blueskyGetProfile(_ actor: String) async throws -> BlueskyProfile {
+		try await provider.decodeJSON(
+			host: "public.api.bsky.app",
+			path: "/xrpc/app.bsky.actor.getProfile",
+			headers: ["Accept": "application/json"],
+			queryItems: [("actor", actor)]
+		)
 	}
 	
 	public func plcDirectoryQuery(

--- a/Sources/ATResolve/Networking.swift
+++ b/Sources/ATResolve/Networking.swift
@@ -18,6 +18,7 @@ extension URLSession: ResponseProviding {
 			throw URLError(.badURL)
 		}
 		var urlRequest = URLRequest(url: url)
+		urlRequest.timeoutInterval = 3
 		urlRequest.httpMethod = request.method.rawValue
 		for (key, value) in request.headers {
 			urlRequest.addValue(value, forHTTPHeaderField: key)

--- a/Sources/ATResolve/ResponseProviding.swift
+++ b/Sources/ATResolve/ResponseProviding.swift
@@ -28,7 +28,7 @@ public struct Request: Sendable {
 	public let queryItems: [(String, String?)]
 }
 
-public protocol ResponseProviding {
+public protocol ResponseProviding: Sendable {
 	func data(for: Request) async throws -> Data
 }
 

--- a/Tests/ATResolveTests/ATResolveTests.swift
+++ b/Tests/ATResolveTests/ATResolveTests.swift
@@ -17,8 +17,8 @@ struct ATResolveTests {
 		#expect(data?.serviceEndpoint == "https://milkcap.us-west.host.bsky.network")
 	}
 	
-	// Custom handle: Managed via DNS TXT record
-	@Test func didForCustomHandle() async throws {
+	@Test
+	func didForDomain() async throws {
 		let resolver = ATResolver(provider: URLSession.shared)
 
 		let did = try await resolver.didForDomain("massicotte.org")
@@ -26,22 +26,21 @@ struct ATResolveTests {
 		#expect(did == "did:plc:klsh7edzj3jmxucibyjqstb3")
 	}
 	
-	// Bluesky: Managed via /.well-known/atproto-did
-	@Test func didForBskySocialHandle() async throws {
+	@Test
+	func blueskyGetProfile() async throws {
 		let resolver = ATResolver(provider: URLSession.shared)
 
-		let did = try await resolver.didForDomain("cjrdev.bsky.social")
-
-		#expect(did == "did:plc:wlef3srsa3hlyzj2hy6yncrh")
+		let profile = try await resolver.blueskyGetProfile("massicotte.org")
+		
+		#expect(profile.did == "did:plc:klsh7edzj3jmxucibyjqstb3")
 	}
 	
-	// Blacksky: Managed via /.well-known/atproto-did
-	@Test func didForMyatprotoSocialHandle() async throws {
+	@Test func bskySocialHandle() async throws {
 		let resolver = ATResolver(provider: URLSession.shared)
 
-		let did = try await resolver.didForDomain("cosmo-dev.myatproto.social")
-
-		#expect(did == "did:plc:ccuttodko4ijw24ga6yln3l6")
+		let profile = try await resolver.resolveHandle("cjrdev.bsky.social")
+		
+		#expect(profile != nil)
 	}
 
 	@Test func decodeWithCustomProvider() async throws {

--- a/Tests/ATResolveTests/ATResolveTests.swift
+++ b/Tests/ATResolveTests/ATResolveTests.swift
@@ -42,6 +42,27 @@ struct ATResolveTests {
 		
 		#expect(profile != nil)
 	}
+	
+	@Test
+	func timedTestWellKnownTimeout() async throws {
+		// The /.well-known endpoint times out for @thisismissem.social
+		// It should time out after 3 seconds, so this test should be ~3 seconds
+		try await timedTest {
+			let resolver = ATResolver(provider: URLSession.shared)
+			let profile = try await resolver.resolveHandle("thisismissem.social")
+			#expect(profile?.did == "did:plc:5w4eqcxzw5jv5qfnmzxcakfy")
+		}
+	}
+	
+	@Test
+	func timedTestDNSTimeout() async throws {
+		// DNS should time out for any .bsky.social handle
+		try await timedTest {
+			let resolver = ATResolver(provider: URLSession.shared)
+			let profile = try await resolver.resolveHandle("cjrdev.bsky.social")
+			#expect(profile?.did == "did:plc:wlef3srsa3hlyzj2hy6yncrh")
+		}
+	}
 
 	@Test func decodeWithCustomProvider() async throws {
 		struct CustomProvider: ResponseProviding {
@@ -59,5 +80,12 @@ struct ATResolveTests {
 		let response = try await resolver.plcDirectoryQuery("did:plc:klsh7edzj3jmxucibyjqstb3")
 		
 		#expect(response.pds?.serviceEndpoint == "https://milkcap.us-west.host.bsky.network")
+	}
+	
+	private func timedTest(_ test: () async throws  -> ()) async throws {
+		let start = CFAbsoluteTimeGetCurrent()
+		try await test()
+		let diff = CFAbsoluteTimeGetCurrent() - start
+		print("This test took \(diff) seconds")
 	}
 }

--- a/Tests/ATResolveTests/ATResolveTests.swift
+++ b/Tests/ATResolveTests/ATResolveTests.swift
@@ -17,8 +17,8 @@ struct ATResolveTests {
 		#expect(data?.serviceEndpoint == "https://milkcap.us-west.host.bsky.network")
 	}
 	
-	@Test
-	func didForDomain() async throws {
+	// Custom handle: Managed via DNS TXT record
+	@Test func didForCustomHandle() async throws {
 		let resolver = ATResolver(provider: URLSession.shared)
 
 		let did = try await resolver.didForDomain("massicotte.org")
@@ -26,21 +26,22 @@ struct ATResolveTests {
 		#expect(did == "did:plc:klsh7edzj3jmxucibyjqstb3")
 	}
 	
-	@Test
-	func blueskyGetProfile() async throws {
+	// Bluesky: Managed via /.well-known/atproto-did
+	@Test func didForBskySocialHandle() async throws {
 		let resolver = ATResolver(provider: URLSession.shared)
 
-		let profile = try await resolver.blueskyGetProfile("massicotte.org")
-		
-		#expect(profile.did == "did:plc:klsh7edzj3jmxucibyjqstb3")
+		let did = try await resolver.didForDomain("cjrdev.bsky.social")
+
+		#expect(did == "did:plc:wlef3srsa3hlyzj2hy6yncrh")
 	}
 	
-	@Test func bskySocialHandle() async throws {
+	// Blacksky: Managed via /.well-known/atproto-did
+	@Test func didForMyatprotoSocialHandle() async throws {
 		let resolver = ATResolver(provider: URLSession.shared)
 
-		let profile = try await resolver.resolveHandle("cjrdev.bsky.social")
-		
-		#expect(profile != nil)
+		let did = try await resolver.didForDomain("cosmo-dev.myatproto.social")
+
+		#expect(did == "did:plc:ccuttodko4ijw24ga6yln3l6")
 	}
 
 	@Test func decodeWithCustomProvider() async throws {


### PR DESCRIPTION
Hi Matt! This may not be the exact way you'd want to implement this, but I wanted to propose an ATResolve update that accounts for the second way people can register handles, via `.well-known` path instead of DNS TXT record, as per:

> Organizations like newsrooms or companies may want to verify multiple affiliated individuals' accounts via subdomains. For example, a newsroom could set its journalists' handles to be @name.newsroom.com, or have multiple accounts for different verticals like @sports.newsroom.com. But managing many individual subdomains via TXT records can be cumbersome. In that case, you can use a non-DNS option by resolving multiple handles via HTTP under a .well-known route.
Instead of using DNS TXT records, you can return each account's DID from the route `https://${handle}/.well-known/atproto-did`. The expected payload is a DID (such as `did:plc:abcdef...`) with content-type `text/plain`. The handle resolution function explicitly expects a `HTTP 200 OK` status. ([source](https://bsky.social/about/blog/4-28-2023-domain-handle-tutorial))

I've found that the DNS check takes a while (~1 min) if the appropriate TXT file isn't there (it falls back appropriately to the getProfile function, it just takes a while to reach there), and in my experience the well-known check can be slow as well if that endpoint doesn't exist, so I'm suggesting racing the DNS check against the `./well-known/atproto-did` and returning whenever we find a value.