### PR TITLE
refactor: make handle resolution methods return non-optional values

### DIFF
--- a/Sources/ATResolve/ATResolver.swift
+++ b/Sources/ATResolve/ATResolver.swift
@@ -78,7 +78,9 @@ public struct ATResolver<Provider: ResponseProviding> {
 				queryItems: [("actor", actor)]
 			)
 		} catch let error as XRPCError
-					where error.error == "InvalidRequest" && error.message?.localizedCaseInsensitiveContains("not found") == true {
+					where error.error == "InvalidRequest" &&
+					(error.message?.localizedCaseInsensitiveContains("not found") == true ||
+					error.message?.localizedCaseInsensitiveContains("invalid app.bsky.actor.getProfile params") == true) {
 			return nil
 		}
 	}

--- a/Sources/ATResolve/ATResolver.swift
+++ b/Sources/ATResolve/ATResolver.swift
@@ -5,6 +5,11 @@ enum ATResolverError: Error {
 	case requestFailed
 }
 
+struct XRPCError: Decodable, Error {
+	let error: String
+	let message: String?
+}
+
 public struct ResolvedData: Codable, Hashable, Sendable {
 	public let did: String
 	public let handle: String
@@ -56,21 +61,26 @@ public struct ATResolver<Provider: ResponseProviding> {
 		return didRecord?.txt.components(separatedBy: "=").last
 	}
 	
-	public func didForHandle(_ handle: String) async throws -> String {
+	public func didForHandle(_ handle: String) async throws -> String? {
 		if let did = try await didForDomain(handle) {
 			return did
 		}
 		
-		return try await blueskyGetProfile(handle).did
+		return try await blueskyGetProfile(handle)?.did
 	}
 	
-	public func blueskyGetProfile(_ actor: String) async throws -> BlueskyProfile {
-		try await provider.decodeJSON(
-			host: "public.api.bsky.app",
-			path: "/xrpc/app.bsky.actor.getProfile",
-			headers: ["Accept": "application/json"],
-			queryItems: [("actor", actor)]
-		)
+	public func blueskyGetProfile(_ actor: String) async throws -> BlueskyProfile? {
+		do {
+			return try await provider.decodeJSON(
+				host: "public.api.bsky.app",
+				path: "/xrpc/app.bsky.actor.getProfile",
+				headers: ["Accept": "application/json"],
+				queryItems: [("actor", actor)]
+			)
+		} catch let error as XRPCError
+					where error.error == "InvalidRequest" && error.message?.localizedCaseInsensitiveContains("not found") == true {
+			return nil
+		}
 	}
 	
 	public func plcDirectoryQuery(
@@ -83,8 +93,10 @@ public struct ATResolver<Provider: ResponseProviding> {
 		)
 	}
 	
-	public func resolveHandle(_ handle: String) async throws -> ResolvedData {
-		let did = try await didForHandle(handle)
+	public func resolveHandle(_ handle: String) async throws -> ResolvedData? {
+		guard let did = try await didForHandle(handle) else {
+			return nil
+		}
 		print("did: \(did)")
 		let directoryResult = try await plcDirectoryQuery(did)
 		

--- a/Sources/ATResolve/ATResolver.swift
+++ b/Sources/ATResolve/ATResolver.swift
@@ -56,7 +56,7 @@ public struct ATResolver<Provider: ResponseProviding> {
 		return didRecord?.txt.components(separatedBy: "=").last
 	}
 	
-	public func didForHandle(_ handle: String) async throws -> String? {
+	public func didForHandle(_ handle: String) async throws -> String {
 		if let did = try await didForDomain(handle) {
 			return did
 		}
@@ -83,11 +83,8 @@ public struct ATResolver<Provider: ResponseProviding> {
 		)
 	}
 	
-	public func resolveHandle(_ handle: String) async throws -> ResolvedData? {
-		guard let did = try await didForHandle(handle) else {
-			return nil
-		}
-
+	public func resolveHandle(_ handle: String) async throws -> ResolvedData {
+		let did = try await didForHandle(handle)
 		print("did: \(did)")
 		let directoryResult = try await plcDirectoryQuery(did)
 		

--- a/Sources/ATResolve/Networking.swift
+++ b/Sources/ATResolve/Networking.swift
@@ -31,8 +31,11 @@ extension URLSession: ResponseProviding {
 		else {
 			print("data:", String(decoding: data, as: UTF8.self))
 			print("response:", response)
-
-			throw ATResolverError.requestFailed
+			if let xrpcError = try? JSONDecoder().decode(XRPCError.self, from: data) {
+				throw xrpcError
+			} else {
+				throw ATResolverError.requestFailed
+			}
 		}
 		return data
 	}

--- a/Tests/ATResolveTests/ATResolveTests.swift
+++ b/Tests/ATResolveTests/ATResolveTests.swift
@@ -12,9 +12,9 @@ struct ATResolveTests {
 
 		let data = try await resolver.resolveHandle("massicotte.org")
 		
-		#expect(data?.did == "did:plc:klsh7edzj3jmxucibyjqstb3")
-		#expect(data?.handle == "massicotte.org")
-		#expect(data?.serviceEndpoint == "https://milkcap.us-west.host.bsky.network")
+		#expect(data.did == "did:plc:klsh7edzj3jmxucibyjqstb3")
+		#expect(data.handle == "massicotte.org")
+		#expect(data.serviceEndpoint == "https://milkcap.us-west.host.bsky.network")
 	}
 	
 	@Test
@@ -40,7 +40,7 @@ struct ATResolveTests {
 
 		let profile = try await resolver.resolveHandle("cjrdev.bsky.social")
 		
-		#expect(profile != nil)
+		#expect(profile.did == "did:plc:wlef3srsa3hlyzj2hy6yncrh")
 	}
 
 	@Test func decodeWithCustomProvider() async throws {

--- a/Tests/ATResolveTests/ATResolveTests.swift
+++ b/Tests/ATResolveTests/ATResolveTests.swift
@@ -44,6 +44,15 @@ struct ATResolveTests {
 		#expect(profile == nil)
 	}
 	
+	@Test
+	func blueskyGetProfileReturnsNilForInvalidFormatHandle() async throws {
+		let resolver = ATResolver(provider: URLSession.shared)
+		
+		let profile = try await resolver.blueskyGetProfile("nonexistent@example.com")
+		
+		#expect(profile == nil)
+	}
+	
 	@Test func bskySocialHandle() async throws {
 		let resolver = ATResolver(provider: URLSession.shared)
 

--- a/Tests/ATResolveTests/ATResolveTests.swift
+++ b/Tests/ATResolveTests/ATResolveTests.swift
@@ -12,9 +12,9 @@ struct ATResolveTests {
 
 		let data = try await resolver.resolveHandle("massicotte.org")
 		
-		#expect(data.did == "did:plc:klsh7edzj3jmxucibyjqstb3")
-		#expect(data.handle == "massicotte.org")
-		#expect(data.serviceEndpoint == "https://milkcap.us-west.host.bsky.network")
+		#expect(data?.did == "did:plc:klsh7edzj3jmxucibyjqstb3")
+		#expect(data?.handle == "massicotte.org")
+		#expect(data?.serviceEndpoint == "https://milkcap.us-west.host.bsky.network")
 	}
 	
 	@Test
@@ -32,7 +32,16 @@ struct ATResolveTests {
 
 		let profile = try await resolver.blueskyGetProfile("massicotte.org")
 		
-		#expect(profile.did == "did:plc:klsh7edzj3jmxucibyjqstb3")
+		#expect(profile?.did == "did:plc:klsh7edzj3jmxucibyjqstb3")
+	}
+	
+	@Test
+	func blueskyGetProfileWithNonexistentHandle() async throws {
+		let resolver = ATResolver(provider: URLSession.shared)
+		
+		let profile = try await resolver.blueskyGetProfile("nonexistent.example.com")
+		
+		#expect(profile == nil)
 	}
 	
 	@Test func bskySocialHandle() async throws {
@@ -40,7 +49,7 @@ struct ATResolveTests {
 
 		let profile = try await resolver.resolveHandle("cjrdev.bsky.social")
 		
-		#expect(profile.did == "did:plc:wlef3srsa3hlyzj2hy6yncrh")
+		#expect(profile?.did == "did:plc:wlef3srsa3hlyzj2hy6yncrh")
 	}
 
 	@Test func decodeWithCustomProvider() async throws {


### PR DESCRIPTION
This PR refactors the handle resolution methods in `ATResolver` to return non-optional values.

Previously, `didForHandle(_:)` and `resolveHandle(_:)` returned `Optional` values, requiring callers to handle `nil` cases. This change updates these methods to return non-optional `String` and `ResolvedData` types, delegating failure handling to Swift’s error handling mechanism (`throws`).